### PR TITLE
Add Docker support for AttendanceChimp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Use the official Python image as the base image
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements.txt file into the container
+COPY requirements.txt .
+
+# Install the required Python packages
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application code into the container
+COPY . .
+
+# Expose the port the application will run on
+EXPOSE 8000
+
+# Run the Django development server
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: build start stop
+
+build:
+	docker-compose build
+
+start:
+	docker-compose up
+
+stop:
+	docker-compose down

--- a/README.md
+++ b/README.md
@@ -30,3 +30,43 @@ AttendanceChimp should have tools to mitigate evasion through duplicate QR codes
 
 ## Architecture
 AttendanceChimp will be built on `python-django` (https://www.djangoproject.com/). Django is a high-level Python web framework that encourages rapid development and clean, pragmatic design. It takes care of much of the hassle of web development, so you can focus on writing your app without needing to reinvent the wheel. Django can run a local web-server and can easily interface with a database backend. We will be using a SQLite databaase backend. SQLite is a database engine written in the C programming language. It is not a standalone app; rather, it is a library that software developers embed in their apps.
+
+## Using Docker to Run the Application
+
+To make it easier to run the application, we have provided a Dockerfile, a docker-compose file, and a Makefile. These files allow you to build, run, and stop the application using Docker containers.
+
+### Dockerfile
+
+The Dockerfile defines the Docker image for the application. It uses the official Python image as the base image, sets the working directory in the container to `/app`, copies the `requirements.txt` file into the container, installs the required Python packages using `pip`, copies the rest of the application code into the container, exposes port 8000, and runs the Django development server.
+
+### docker-compose.yml
+
+The `docker-compose.yml` file defines the services required to run the application. It includes a web service that builds from the Dockerfile, sets the command to run the Django development server, mounts the current directory as a volume in the container, exposes port 8000, and defines a database service using the `postgres:13` image with the necessary environment variables and a volume for the database data.
+
+### Makefile
+
+The Makefile provides easy-to-use commands for building and running the Docker containers. It defines a `.PHONY` target for `build`, `up`, and `down`, and provides the following commands:
+
+* `make build`: Builds the Docker images.
+* `make up`: Starts the Docker containers.
+* `make down`: Stops the Docker containers.
+
+### Building, Running, and Stopping the Application
+
+To build the Docker images, run the following command:
+
+```sh
+make build
+```
+
+To start the Docker containers, run the following command:
+
+```sh
+make up
+```
+
+To stop the Docker containers, run the following command:
+
+```sh
+make down
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+
+services:
+  web:
+    build: .
+    command: python manage.py runserver 0.0.0.0:8000
+    volumes:
+      - .:/app
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+
+  db:
+    image: postgres:13
+    environment:
+      POSTGRES_DB: attendancechimp
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Django==4.1.7
+psycopg2-binary==2.9.3


### PR DESCRIPTION
Add instructions to the `README.md` for using Docker to run the application.

* **Dockerfile**
  - Use the official Python image as the base image.
  - Set the working directory in the container to `/app`.
  - Copy the `requirements.txt` file into the container.
  - Install the required Python packages using `pip`.
  - Copy the rest of the application code into the container.
  - Expose port 8000.
  - Run the Django development server.

* **docker-compose.yml**
  - Define the version as '3.8'.
  - Define the web service to build from the Dockerfile.
  - Set the command to run the Django development server.
  - Mount the current directory as a volume in the container.
  - Expose port 8000.
  - Define the database service using the `postgres:13` image.
  - Set the environment variables for the database.
  - Mount a volume for the database data.

* **Makefile**
  - Define a `.PHONY` target for `build`, `start`, and `stop`.
  - Define the `build` target to run `docker-compose build`.
  - Define the `start` target to run `docker-compose up`.
  - Define the `stop` target to run `docker-compose down`.

* **requirements.txt**
  - Add Django version 4.1.7.
  - Add psycopg2-binary version 2.9.3.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/egouilliard/attendance_chimp?shareId=e511d650-901e-4075-a8d1-ded4659d677d).